### PR TITLE
Upgrade to current version of @google-cloud/storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const path    = require('path');
-const storage = require('@google-cloud/storage');
-const fsp     = require('fs-promise');
-const {exec}  = require('mz/child_process');
+const path      = require('path');
+const {Storage} = require('@google-cloud/storage');
+const fsp       = require('fs-promise');
+const {exec}    = require('mz/child_process');
 
 function fetchCurrentVersion(ui, configFile) {
   ui.writeLine(`fetching current app version from ${configFile.bucket.name}/${configFile.name}`);
@@ -81,7 +81,7 @@ class GCSDownloader {
       return Promise.reject(new AppNotFoundError());
     }
 
-    const gcs        = storage(this.authentication);
+    const gcs        = new Storage(this.authentication);
     const configFile = gcs.bucket(this.configBucket).file(this.configKey);
 
     return fetchCurrentVersion(this.ui, configFile).then(({bucket: appBucket, key: appKey}) => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Keita Urashima <ursm@ursm.jp>",
   "license": "MIT",
   "dependencies": {
-    "@google-cloud/storage": "^0.4.0",
+    "@google-cloud/storage": "^2.3.0",
     "fs-promise": "^1.0.0",
     "mz": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-gcs-downloader",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A FastBoot App Server downloader for Google Cloud Storage",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Prompted by wanting to get the downstream dependency on `grpc` to a high enough version that precompiled binaries are available for Node 10.13 LTS.